### PR TITLE
1. [Stryk] Stryke kulepunkt kjøring forbudt

### DIFF
--- a/gov-bydelsprogram-2023-2027.md
+++ b/gov-bydelsprogram-2023-2027.md
@@ -331,7 +331,6 @@ Middelalderparken og en bedre kobling mot Bjørvika
 * Redusere hastigheten på Grenseveien og sikre bedre fortau og sykkelveier.
 * Gjøre Gladengveien, Ensjøveien og Strømsveien tryggere for myke trafikanter ved å ytterligere redusere hastighet og gjennomkjøring.
 * Bygge et nytt kryss i skjæringen Gladengveien og Ensjøveien.
-* Gjøre det forbudt for biler å krysse bommen på Galgeberg som skaper mye trafikkgjennomgang gjennom Vålerenga.
 * Sørge for at det blir regulert tilstrekkelig med barnehager, skoler og grøntarealer i nye boligområder som i Hovinbyen.
 * Bedre trafikkforbindelsen mellom Bryn og Carl Berners plass med trikk i Østensjøveien/Grenseveien.
 * Tilrettelegge for flere elbilparkeringsplasser på Valle, Lilleberg og Malerhaugen.


### PR DESCRIPTION
Innstilling: Vedtatt

Innsendt av Fredrik Lading

Forslag:
Stryke kulepunkt kjøring forbudt

Begrunnelse:
Allerede satt opp skilt 306.1 "Forbudt for Motorvogn" på begge sider

Kommentar:


Programkomiteens begrunnelse:
Punktet ikke relevant, da dette allerede er innført