### PR TITLE
5. [Tillegg] B – nytt kulepunkt: At det fremtidige, permanente busstoppet for 
Sørenga blir innerst i Lohavn

### DIFF
--- a/gov-bydelsprogram-2023-2027.md
+++ b/gov-bydelsprogram-2023-2027.md
@@ -206,6 +206,7 @@ reise miljøvennlig
 * 20-bussen skal gå hele veien til Kværnerbyen/Svartdalsparken, via Dahlhaugs- og Enebakkveien slik at Svartdalsparken og området blir
 lettere tilgjengelig for bydelen.
 * At 81-bussen også skal kjøre innom Sørenga og at Sørenga kan bli teststed for selvkjørende busser
+* At det fremtidige, permanente busstoppet for Sørenga blir innerst i Lohavn
 
 ## Fremtidens T-banenett
 T-banen er grunnstammen i kollektivtrafikken i Oslo. T-banenettet må utvides for å nå nye områder, og kapasiteten gjennom sentrum må økes for å


### PR DESCRIPTION
Innstilling: Vedtatt

Innsendt av Bjørn Magne Eggen

Forslag:
B – nytt kulepunkt: At det fremtidige, permanente busstoppet for 
Sørenga blir innerst i Lohavn

Begrunnelse:
Lett tilgjengelig fra Sørenga, for skolen som bygges, 
og mot Grønlia. Dersom ordinære busser skal ut på Sørenga for å 
snu, blir disse forstyrrende og turen tar dessuten mye lengre tid  
redusert bruk. 
Dette er ikke i motstrid til ev. selvkjørende minibusser

Kommentar:
Kommet inn etter frist

Programkomiteens begrunnelse:
Linje 251 dekker behovet for bussrute på Sørenga i første omgang, frem til evt. løsning med selvkjørende busser er på plass