### PR TITLE
6. [Tillegg] B – nytt kulepunkt før linje 253: At det fremtidige, permanente busstoppet for 
Sørenga blir innerst i Lohavn

### DIFF
--- a/gov-bydelsprogram-2023-2027.md
+++ b/gov-bydelsprogram-2023-2027.md
@@ -300,6 +300,7 @@ fra Tøyen torg.
 **I Bispevika delbydel (Bjørvika og Sørenga) vil Gamle Oslo Venstre:**
 
 * Etablere en bussrute som gir besøkende og beboere tilgang til offentlig transport, på Sørenga i første omgang.
+* At det fremtidige, permanente busstoppet for Sørenga blir innerst i Lohavn
 * Etablere et grøntlokk med sykkeltrasé over jernbanelinjene ved Oslo S for å skape en sammenhengende park mot
 Middelalderparken og en bedre kobling mot Grønland
 * Tilrettelegge for foreninger med fokus på sjøliv, for eksempel kajakklubb, roklubb, seiling og vindsurfing


### PR DESCRIPTION
Innstilling: Vedtatt

Innsendt av Bjørn Magne Eggen

Forslag:
B – nytt kulepunkt før linje 253: At det fremtidige, permanente busstoppet for 
Sørenga blir innerst i Lohavn

Begrunnelse:
Lett tilgjengelig fra Sørenga, for skolen som bygges, 
og mot Grønlia. Dersom ordinære busser skal ut på Sørenga for å 
snu, blir disse forstyrrende og turen tar dessuten mye lengre tid = redusert bruk. 
Dette er ikke i motstrid til ev. selvkjørende minibusser

Kommentar:
Kommet inn etter frist

Programkomiteens begrunnelse:
Linje 251 dekker behovet for bussrute på Sørenga i første omgang, frem til evt. løsning med selvkjørende busser er på plass