### PR TITLE
16. [Endre] Sørge for at felles henvisningsmottak ivaretar bydelens innbyggere sine behov, og at det er tydelig for bydelens beboere hvordan de søker behandling hos psykolog/psykiater

### DIFF
--- a/gov-bydelsprogram-2023-2027.md
+++ b/gov-bydelsprogram-2023-2027.md
@@ -788,8 +788,7 @@ det mulig å fungere i eget nærmiljø.
 **Gamle Oslo Venstre vil:**
 
 * legge til rette for et lavterskeltilbud i bydelen der et er mulig å få psykisk helsehjelp uten krav om henvisning fra fastlegen
-* kreve at helseforetakene utarbeider en jevnlig oppdatert liste over ventelistene hos de ulike psykologer/psykiatere i Oslo,
-og gjøre bydelens beboere kjent med hvor de selv kan undersøke ventelister og søke behandling
+* sørge for at felles henvisningsmottak ivaretar bydelens innbyggere sine behov, og at det er tydelig for bydelens beboere hvordan de søker behandling hos psykolog/psykiater
 * tilby lavterskel samtaletilbud med psykiatrisk sykepleier i bydelen, organisert i tilknytning til frisklivssentralen og/eller
 helsestasjon
 * gi pasienter med kombinerte rus- og psykiske problemer integrert behandling for begge lidelser


### PR DESCRIPTION
Innstilling: Vedtatt

Innsendt av Bjørn Magne Eggen

Forslag:
Sørge for at felles henvisningsmottak ivaretar bydelens innbyggere sine behov, og at det er tydelig for bydelens beboere hvordan de søker behandling hos psykolog/psykiater

Begrunnelse:
Vedr. « ... ventelistene hos de ulike psykologer/psykiatere i Oslo, ...»
(Kommentar: Nå innføres felles henvisningsmottak  sykehusene får alle 
henvisninger og formidler videre til psykologer og psykiatere som er 
forpliktet til å ta imot. Dette punktet er fortsatt viktig, men det løses på en 
annen / bedre måte.).

Kommentar:
Kommet inn etter frist

Programkomiteens begrunnelse:
Den gamle intensjonen i punktet er allerede ivaretatt ved utrulling av felles henvisningsmottak.
Endirngen skrevet av P.K., ber om møtets godkjenning for å endre denne redaksjonellt senere for å tydeliggjøre