### PR TITLE
17. [Endring] at Oslo kommune og politiet fortsetter samarbeidet om SaLTo for å bekjempe og forebygge rus og kriminalitet ->
at Oslo kommune og politiet fortsetter med  samarbeidsmodellen SaLTo - modellen som er laget for å bekjempe og forebygge rus
og kriminalitet i Oslo

### DIFF
--- a/gov-bydelsprogram-2023-2027.md
+++ b/gov-bydelsprogram-2023-2027.md
@@ -866,7 +866,7 @@ etater og bydelens krefter til å spille på lag i kampen mot utrygghet.
 
 **Gamle Oslo Venstre vil:**
 
-* at Oslo kommune og politiet fortsetter samarbeidet om SaLTo for å bekjempe og forebygge rus og kriminalitet
+* at Oslo kommune og politiet fortsetter med  samarbeidsmodellen SaLTo - modellen som er laget for å bekjempe og forebygge rus og kriminalitet i Oslo
 * sikre at det er god belysning, som ikke skaper lysforurensing, rundt parker, plasser og gater der folk ferdes å nattestid
 * ha mer synlig politi som regelmessig patruljerer i gatene, særlig sentrumsnære strøk i bydelen
 * etablere sosiale og kulturelle møteplasser der en kan samles i trygge omgivelser

--- a/gov-bydelsprogram-2023-2027.md
+++ b/gov-bydelsprogram-2023-2027.md
@@ -866,7 +866,7 @@ etater og bydelens krefter til å spille på lag i kampen mot utrygghet.
 
 **Gamle Oslo Venstre vil:**
 
-* at Oslo kommune og politiet fortsetter med  samarbeidsmodellen SaLTo - modellen som er laget for å bekjempe og forebygge rus og kriminalitet i Oslo
+* videreføre og styrke det kriminalitetsforebyggende SaLTo-samarbeidet mellom kommunen og politiet
 * sikre at det er god belysning, som ikke skaper lysforurensing, rundt parker, plasser og gater der folk ferdes å nattestid
 * ha mer synlig politi som regelmessig patruljerer i gatene, særlig sentrumsnære strøk i bydelen
 * etablere sosiale og kulturelle møteplasser der en kan samles i trygge omgivelser


### PR DESCRIPTION
Innstilling: Vedtatt

Innsendt av Bjørn Magne Eggen

Forslag:
at Oslo kommune og politiet fortsetter samarbeidet om SaLTo for å bekjempe og forebygge rus og kriminalitet ->
at Oslo kommune og politiet fortsetter med  samarbeidsmodellen SaLTo - modellen som er laget for å bekjempe og forebygge rus
og kriminalitet i Oslo

Begrunnelse:


Kommentar:
Kommet inn etter frist

Programkomiteens begrunnelse:
Fortydeliggjøring av hva SaLTo er. Endirngen skrevet av P.K., ber om møtets godkjenning for å endre denne redaksjonellt senere for å tydeliggjøre